### PR TITLE
Use PhotoPicker and target API 34

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:name=".CMediaPlayerApplication"
@@ -13,11 +14,10 @@
         android:supportsRtl="false"
         android:usesCleartextTraffic="true"
         android:theme="@style/Theme.CMediaPlayer"
-        tools:targetApi="33">
+        tools:targetApi="34">
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.CMediaPlayer">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -47,9 +47,17 @@
                 <data android:mimeType="application/x-flac"/>
             </intent-filter>
         </activity>
+
+        <!-- Trigger Google Play services to install the backported photo picker module. -->
+        <service android:name="com.google.android.gms.metadata.ModuleDependencies"
+            android:enabled="false"
+            android:exported="false"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+            </intent-filter>
+            <meta-data android:name="photopicker_activity:0:required" android:value="" />
+        </service>
     </application>
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 </manifest>

--- a/app/src/main/java/com/cattailsw/mediaplayer/MainActivity.kt
+++ b/app/src/main/java/com/cattailsw/mediaplayer/MainActivity.kt
@@ -8,6 +8,7 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Column
@@ -62,8 +63,10 @@ class MainActivity : ComponentActivity() {
         }
 
         setContent {
-            val openDocument = rememberLauncherForActivityResult(
-                contract = ActivityResultContracts.OpenDocument(),
+            // TODO: support non-GMS devices by checking if this is not available and fall back
+            // to SAF document opening?
+            val pickMedia = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.PickVisualMedia(),
                 onResult = { uri ->
                     viewModel.handleResult(uri)
                 }
@@ -90,7 +93,7 @@ class MainActivity : ComponentActivity() {
                 }
 
                 is MainState.OpenFile -> {
-                    openDocument.launch(arrayOf("video/*"))
+                    pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.VideoOnly))
                 }
 
                 is MainState.LaunchMedia -> {

--- a/app/src/main/java/com/cattailsw/mediaplayer/MainViewModel.kt
+++ b/app/src/main/java/com/cattailsw/mediaplayer/MainViewModel.kt
@@ -18,12 +18,7 @@ class MainViewModel: ViewModel() {
 
     fun openLocalFileBrowser() {
         viewModelScope.launch {
-            // open SAF to read some kind of files
-            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                addCategory(Intent.CATEGORY_OPENABLE)
-                type="video/*"
-            }
-            _state.emit(MainState.OpenFile(intent))
+            _state.emit(MainState.OpenFile)
         }
     }
 
@@ -62,6 +57,6 @@ class MainViewModel: ViewModel() {
 sealed class MainState {
     object Empty: MainState()
     object ErrorOpen: MainState()
-    data class OpenFile(val intentToLaunch: Intent): MainState()
+    object OpenFile: MainState()
     data class LaunchMedia(val uri: Uri): MainState()
 }


### PR DESCRIPTION
use PickVisualMedia and use visual media thingy

this removes the need of two permissions and should be the only thing to migrate when targeting API 34

tested on Android 14Beta, Android 12, Kindle Fire HD10+ with side-loaded GPlay